### PR TITLE
Update duokai.sh

### DIFF
--- a/duokai.sh
+++ b/duokai.sh
@@ -75,5 +75,6 @@ docker exec $container_id bash -c "\
 
 
 done
-
+# 重启所有docker镜像 让设置的磁盘容量生效
+docker restart $(docker ps -a -q)
 echo "==============================所有节点均已设置并启动===================================."


### PR DESCRIPTION
设置磁盘容量后，不重启服务 会导致运行的节点使用默认的2g磁盘运行。
重启之后就正常了